### PR TITLE
Fix: Correct optional binding for non-optional CGRect return value

### DIFF
--- a/CoreMLPlayer/Views/SubViews/DetectionView.swift
+++ b/CoreMLPlayer/Views/SubViews/DetectionView.swift
@@ -24,7 +24,8 @@ struct DetectionView: View {
     
     var body: some View {
         GeometryReader { geometry in
-            if let videoSize, let videoRect = getVideoRect(geometrySize: geometry.size, videoSize: videoSize) {
+            if let videoSize {
+                let videoRect = getVideoRect(geometrySize: geometry.size, videoSize: videoSize)
                 ZStack {
                     VStack { EmptyView() }
                         .frame(width: videoRect.width, height: videoRect.height)


### PR DESCRIPTION
## Summary
- Fixed build error in `DetectionView.swift:27`
- Changed `if let videoRect = getVideoRect(...)` to `let videoRect = getVideoRect(...)` 
- The `getVideoRect()` function returns `CGRect` (non-optional), so optional binding was incorrect

## Test plan
- Build succeeds without errors
- App launches and runs correctly

## Before
```
error: initializer for conditional binding must have Optional type, not 'CGRect'
** BUILD FAILED **
```

## After
```
** BUILD SUCCEEDED **
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)